### PR TITLE
Remove [[nodiscard]] for C++11 compatibility

### DIFF
--- a/include/args.hpp
+++ b/include/args.hpp
@@ -203,7 +203,7 @@ class ArgumentParser
         }
     }
 
-    [[nodiscard]] std::string helpStr() const
+    std::string helpStr() const
     {
         std::string help;
         help += "  ";


### PR DESCRIPTION
Compiling x64dbg using Visual Studio 2013 complains about invalid attributes and doesn't recognize the `[[nodiscard]]`.
Fixes #2 